### PR TITLE
Let the OpenFL ui specify a custom path of a Project XML, while continue...

### DIFF
--- a/common/src/com/intellij/plugins/haxe/module/HaxeModuleSettingsBase.java
+++ b/common/src/com/intellij/plugins/haxe/module/HaxeModuleSettingsBase.java
@@ -63,6 +63,8 @@ public interface HaxeModuleSettingsBase {
 
   String getNmmlPath();
 
+  String getOpenFLXmlPath();
+
   void setHxmlPath(String hxmlPath);
 
   boolean isUseHxmlToBuild();

--- a/common/src/com/intellij/plugins/haxe/module/impl/HaxeModuleSettingsBaseImpl.java
+++ b/common/src/com/intellij/plugins/haxe/module/impl/HaxeModuleSettingsBaseImpl.java
@@ -40,6 +40,7 @@ public class HaxeModuleSettingsBaseImpl implements HaxeModuleSettingsBase {
   protected OpenFLTarget openFLTarget = OpenFLTarget.FLASH;
   protected String hxmlPath = "";
   protected String nmmlPath = "";
+  protected String openflxmlPath = "";
   protected String openFLPath = "";
   protected int buildConfig = 0;
 
@@ -158,6 +159,9 @@ public class HaxeModuleSettingsBaseImpl implements HaxeModuleSettingsBase {
     return nmmlPath;
   }
 
+  public String getOpenFLXmlPath() {
+    return openflxmlPath;
+  }
 
   public void setHxmlPath(String hxmlPath) {
     this.hxmlPath = hxmlPath;
@@ -181,6 +185,10 @@ public class HaxeModuleSettingsBaseImpl implements HaxeModuleSettingsBase {
 
   public void setNmmlPath(String nmmlPath) {
     this.nmmlPath = nmmlPath;
+  }
+
+  public void setOpenFLXMLPath(String openflxmlPath) {
+    this.openflxmlPath = openflxmlPath;
   }
 
   public void setBuildConfig(int buildConfig) {

--- a/common/src/com/intellij/plugins/haxe/util/HaxeCommonCompilerUtil.java
+++ b/common/src/com/intellij/plugins/haxe/util/HaxeCommonCompilerUtil.java
@@ -258,6 +258,10 @@ public class HaxeCommonCompilerUtil {
     commandLine.add("openfl");
     commandLine.add("build");
 
+    if(!StringUtil.isEmpty(settings.getOpenFLXmlPath())) {
+      commandLine.add(settings.getOpenFLXmlPath());
+    }
+
     commandLine.add(settings.getOpenFLTarget().getTargetFlag());
 
     commandLine.add("-verbose");

--- a/jps-plugin/src/org/jetbrains/jps/haxe/model/module/impl/JpsHaxeModuleSettingsImpl.java
+++ b/jps-plugin/src/org/jetbrains/jps/haxe/model/module/impl/JpsHaxeModuleSettingsImpl.java
@@ -140,6 +140,11 @@ public class JpsHaxeModuleSettingsImpl extends JpsElementBase<JpsHaxeModuleSetti
   }
 
   @Override
+  public String getOpenFLXmlPath() {
+    return mySettingsBase.getOpenFLXmlPath();
+  }
+
+  @Override
   public void setHxmlPath(String hxmlPath) {
     mySettingsBase.setHxmlPath(hxmlPath);
   }

--- a/src/com/intellij/plugins/haxe/HaxeBundle.properties
+++ b/src/com/intellij/plugins/haxe/HaxeBundle.properties
@@ -138,3 +138,4 @@ inspections.group.name=Haxe
 haxe.inspection.unused.import.name=Unused import statement
 haxe.fix.optimize.imports=Optimize imports
 haxe.inspection.unresolved.symbol=Unresolved symbol
+haxe.openfl.xmlproject=OpenFL Project XML \:

--- a/src/com/intellij/plugins/haxe/ide/projectStructure/ui/HaxeConfigurationEditor.form
+++ b/src/com/intellij/plugins/haxe/ide/projectStructure/ui/HaxeConfigurationEditor.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="535" height="551"/>
+      <xy x="20" y="20" width="535" height="553"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -257,7 +257,7 @@
                       </component>
                     </children>
                   </grid>
-                  <grid id="b1a5" binding="myOpenFLFilePanel" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                  <grid id="b1a5" binding="myOpenFLFilePanel" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                     <margin top="0" left="0" bottom="0" right="0"/>
                     <constraints>
                       <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -276,6 +276,20 @@
                       <component id="39470" class="com.intellij.ui.RawCommandLineEditor">
                         <constraints>
                           <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="7" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties/>
+                      </component>
+                      <component id="8ff70" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="com/intellij/plugins/haxe/HaxeBundle" key="haxe.openfl.xmlproject"/>
+                        </properties>
+                      </component>
+                      <component id="f6736" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="myOpenFLFileChooserTextField">
+                        <constraints>
+                          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties/>
                       </component>

--- a/src/com/intellij/plugins/haxe/ide/projectStructure/ui/HaxeConfigurationEditor.java
+++ b/src/com/intellij/plugins/haxe/ide/projectStructure/ui/HaxeConfigurationEditor.java
@@ -84,6 +84,7 @@ public class HaxeConfigurationEditor {
   private JPanel myOpenFLFilePanel;
   private JPanel myBuildFilePanel;
   private JPanel myCompilerOptionsWrapper;
+  private TextFieldWithBrowseButton myOpenFLFileChooserTextField;
 
   private HaxeTarget selectedHaxeTarget = HaxeTarget.NEKO;
   private NMETarget selectedNmeTarget = NMETarget.FLASH;
@@ -187,7 +188,9 @@ public class HaxeConfigurationEditor {
             return super.isFileVisible(file, showHiddenFiles) &&
                    (file.isDirectory()
                     || (isNMML ? "nmml" : "hxml").equalsIgnoreCase(file.getExtension())
-                    || (isOpenFL && "project.xml".equalsIgnoreCase(file.getName())));
+                    || (isOpenFL && "project.xml".equalsIgnoreCase(file.getName()))
+                    || (isOpenFL && "Project.xml".equalsIgnoreCase(file.getName()))
+                   );
           }
         };
         final VirtualFile file = FileChooser.chooseFile(descriptor, getMainPanel(), null, moduleFile.getParent());
@@ -196,7 +199,12 @@ public class HaxeConfigurationEditor {
           if (isNMML) {
             myNMEFileChooserTextField.setText(path);
           }
-          else {
+          else if(isOpenFL)
+          {
+            myOpenFLFileChooserTextField.setText(path);
+          }
+          else
+          {
             myHxmlFileChooserTextField.setText(path);
           }
           updateComponents();
@@ -206,6 +214,7 @@ public class HaxeConfigurationEditor {
 
     myHxmlFileChooserTextField.getButton().addActionListener(fileChooserListener);
     myNMEFileChooserTextField.getButton().addActionListener(fileChooserListener);
+    myOpenFLFileChooserTextField.getButton().addActionListener(fileChooserListener);
 
     myEditMacrosesButton.addActionListener(new ActionListener() {
       @Override
@@ -260,6 +269,7 @@ public class HaxeConfigurationEditor {
 
     if (!myOpenFLFileRadioButton.isSelected() && containsOpenFL) {
       myBuildFilePanel.remove(myOpenFLFilePanel);
+      myBuildFilePanel.remove(myOpenFLFileChooserTextField);
     }
 
     final GridConstraints constraints = new GridConstraints();
@@ -365,6 +375,8 @@ public class HaxeConfigurationEditor {
 
     result = result || !FileUtil.toSystemIndependentName(myHxmlFileChooserTextField.getText()).equals(settings.getHxmlPath());
 
+    result = result || !FileUtil.toSystemIndependentName(myOpenFLFileChooserTextField.getText()).equals(settings.getOpenFLXmlPath());
+
     result = result || !settings.getArguments().equals(myAppArguments.getText());
     result = result || !settings.getNmeFlags().equals(myNMEArguments.getText());
     result = result || (settings.isExcludeFromCompilation() ^ myExcludeFromCompilationCheckBox.isSelected());
@@ -396,6 +408,7 @@ public class HaxeConfigurationEditor {
     final String url = myExtension.getCompilerOutputUrl();
     myFolderTextField.setText(VfsUtil.urlToPath(url));
     myHxmlFileChooserTextField.setText(settings.getHxmlPath());
+    myOpenFLFileChooserTextField.setText(settings.getOpenFLXmlPath());
     myNMEFileChooserTextField.setText(settings.getNmmlPath());
     myNMEArguments.setText(settings.getNmeFlags());
 
@@ -426,6 +439,7 @@ public class HaxeConfigurationEditor {
     settings.setOutputFileName(myOutputFileNameTextField.getText());
 
     settings.setHxmlPath(FileUtil.toSystemIndependentName(myHxmlFileChooserTextField.getText()));
+    settings.setOpenFLXMLPath(FileUtil.toSystemIndependentName(myOpenFLFileChooserTextField.getText()));
     settings.setNmmlPath(FileUtil.toSystemIndependentName(myNMEFileChooserTextField.getText()));
 
     settings.setBuildConfig(getCurrentBuildConfig());

--- a/src/com/intellij/plugins/haxe/runner/OpenFLRunningState.java
+++ b/src/com/intellij/plugins/haxe/runner/OpenFLRunningState.java
@@ -26,6 +26,7 @@ import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.plugins.haxe.HaxeCommonBundle;
 import com.intellij.plugins.haxe.config.OpenFLTarget;
 import com.intellij.plugins.haxe.config.sdk.HaxeSdkData;
@@ -81,6 +82,10 @@ public class OpenFLRunningState extends CommandLineState {
     commandLine.addParameter("run");
     commandLine.addParameter("openfl");
     commandLine.addParameter(myRunInTest ? "test" : "run");
+
+    if(!StringUtil.isEmpty(settings.getOpenFLXmlPath())) {
+      commandLine.addParameter(settings.getOpenFLXmlPath());
+    }
 
     for (String flag : settings.getOpenFLTarget().getFlags()) {
       commandLine.addParameter(flag);


### PR DESCRIPTION
Let the OpenFL ui to specify a custom path of a Project XML, while continue to use the project dir as cwd for empty value. I had some NME projects using an nmml file in another path, this enables the same custom path for the project file for OpenFL.
