### PR TITLE
Parse warnings, and treat errors as errors.

### DIFF
--- a/common/src/com/intellij/plugins/haxe/compilation/HaxeCompilerError.java
+++ b/common/src/com/intellij/plugins/haxe/compilation/HaxeCompilerError.java
@@ -15,6 +15,7 @@
  */
 package com.intellij.plugins.haxe.compilation;
 
+import com.intellij.openapi.compiler.CompilerMessageCategory;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
 import org.jetbrains.annotations.NotNull;
@@ -26,16 +27,22 @@ import java.io.File;
  * @author: Fedor.Korotkov
  */
 public class HaxeCompilerError {
+  private final CompilerMessageCategory category;
   private final String errorMessage;
   private final String path;
   private final int line;
   private final int column;
 
-  public HaxeCompilerError(String errorMessage, String path, int line, int column) {
+  public HaxeCompilerError(CompilerMessageCategory category, String errorMessage, String path, int line, int column) {
+    this.category = category;
     this.errorMessage = errorMessage;
     this.path = path;
     this.line = line;
     this.column = column;
+  }
+
+  public CompilerMessageCategory getCategory() {
+    return category;
   }
 
   public String getErrorMessage() {
@@ -77,9 +84,14 @@ public class HaxeCompilerError {
     final String path = (lineSeparationIndex == -1) ? pathAndLine : pathAndLine.substring(0, lineSeparationIndex);
 
     final int errorSeparationIndex = message.indexOf(':', pathSeparationIndex);
-    String errorMessage = null;
+    CompilerMessageCategory category = CompilerMessageCategory.ERROR;
+    String errorMessage = "";
     if (errorSeparationIndex != -1) {
-      errorMessage = message.substring(errorSeparationIndex + 1);
+      errorMessage = message.substring(errorSeparationIndex + 1).trim();
+      if (errorMessage.startsWith("Warning : ")) {
+        errorMessage = errorMessage.substring("Warning : ".length()).trim();
+        category = CompilerMessageCategory.WARNING;
+      }
     }
 
     String charsOrLines;
@@ -110,6 +122,6 @@ public class HaxeCompilerError {
       return null;
     }
 
-    return new HaxeCompilerError(StringUtil.trimLeading(StringUtil.trimTrailing(StringUtil.notNullize(errorMessage))), filePath, line, column);
+    return new HaxeCompilerError(category, errorMessage, filePath, line, column);
   }
 }

--- a/src/com/intellij/plugins/haxe/compilation/HaxeCompilerUtil.java
+++ b/src/com/intellij/plugins/haxe/compilation/HaxeCompilerUtil.java
@@ -42,7 +42,7 @@ public class HaxeCompilerUtil {
     }
 
     context.addMessage(
-      CompilerMessageCategory.WARNING,
+      compilerError.getCategory(),
       compilerError.getErrorMessage(),
       VfsUtilCore.pathToUrl(compilerError.getPath()),
       compilerError.getLine(),

--- a/testSrc/com/intellij/plugins/haxe/ide/HaxeCompilerErrorParsingTest.java
+++ b/testSrc/com/intellij/plugins/haxe/ide/HaxeCompilerErrorParsingTest.java
@@ -15,6 +15,7 @@
  */
 package com.intellij.plugins.haxe.ide;
 
+import com.intellij.openapi.compiler.CompilerMessageCategory;
 import com.intellij.plugins.haxe.compilation.HaxeCompilerError;
 import junit.framework.TestCase;
 
@@ -30,6 +31,7 @@ public class HaxeCompilerErrorParsingTest extends TestCase {
     final HaxeCompilerError compilerError = HaxeCompilerError.create(rootPath, error, false);
 
     assertNotNull(compilerError);
+    assertEquals(CompilerMessageCategory.ERROR, compilerError.getCategory());
     assertEquals("C:/Users/fedor.korotkov/workspace/haxe-bubble-breaker/src/Main.hx", compilerError.getPath());
     assertEquals("Class not found : StringTools212", compilerError.getErrorMessage());
     assertEquals(5, compilerError.getLine());
@@ -42,6 +44,7 @@ public class HaxeCompilerErrorParsingTest extends TestCase {
     final HaxeCompilerError compilerError = HaxeCompilerError.create(rootPath, error, false);
 
     assertNotNull(compilerError);
+    assertEquals(CompilerMessageCategory.ERROR, compilerError.getCategory());
     assertEquals("C:/Users/fedor.korotkov/workspace/haxe-bubble-breaker/src/Main.hx", compilerError.getPath());
     assertEquals("Class not found : StringTools212", compilerError.getErrorMessage());
     assertEquals(5, compilerError.getLine());
@@ -54,6 +57,7 @@ public class HaxeCompilerErrorParsingTest extends TestCase {
     final HaxeCompilerError compilerError = HaxeCompilerError.create(rootPath, error, false);
 
     assertNotNull(compilerError);
+    assertEquals(CompilerMessageCategory.ERROR, compilerError.getCategory());
     assertEquals("/trees/test/./HelloWorld.hx", compilerError.getPath());
     assertEquals("Unknown identifier : addEvetListener", compilerError.getErrorMessage());
     assertEquals(12, compilerError.getLine());
@@ -66,6 +70,7 @@ public class HaxeCompilerErrorParsingTest extends TestCase {
     final HaxeCompilerError compilerError = HaxeCompilerError.create(rootPath, error, false);
 
     assertNotNull(compilerError);
+    assertEquals(CompilerMessageCategory.ERROR, compilerError.getCategory());
     assertEquals("/an/absolute/path/HelloWorld.hx", compilerError.getPath());
     assertEquals("Unknown identifier : addEvetListener", compilerError.getErrorMessage());
     assertEquals(12, compilerError.getLine());
@@ -78,8 +83,22 @@ public class HaxeCompilerErrorParsingTest extends TestCase {
     final HaxeCompilerError compilerError = HaxeCompilerError.create(rootPath, error, false);
 
     assertNotNull(compilerError);
+    assertEquals(CompilerMessageCategory.ERROR, compilerError.getCategory());
     assertEquals("/trees/test/hello/HelloWorld.hx", compilerError.getPath());
     assertEquals("Interfaces cannot implement another interface (use extends instead)", compilerError.getErrorMessage());
+    assertEquals(18, compilerError.getLine());
+    assertEquals(-1, compilerError.getColumn());
+  }
+
+  public void testWarnings() {
+    final String error = "hello/HelloWorld.hx:18: lines 18-24 : Warning : Danger, Will Robinson!";
+    final String rootPath = "/trees/test";
+    final HaxeCompilerError compilerError = HaxeCompilerError.create(rootPath, error, false);
+
+    assertNotNull(compilerError);
+    assertEquals(CompilerMessageCategory.WARNING, compilerError.getCategory());
+    assertEquals("/trees/test/hello/HelloWorld.hx", compilerError.getPath());
+    assertEquals("Danger, Will Robinson!", compilerError.getErrorMessage());
     assertEquals(18, compilerError.getLine());
     assertEquals(-1, compilerError.getColumn());
   }


### PR DESCRIPTION
At least on my system, it seems that Haxe compiler errors always show up as warnings in IDEA.

This is my attempt to fix that... but I haven't actually got it working. For whatever reason I can't figure out, even changing HaxeCompilerUtil.hx:45 to always pass ERROR still causes things to show up as warnings.
